### PR TITLE
21 Add capture button and disable on click.

### DIFF
--- a/Android/app/src/main/res/drawable/capture_button.xml
+++ b/Android/app/src/main/res/drawable/capture_button.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Normal state -->
+    <item android:drawable="@drawable/capture_button_not_pressed" android:state_pressed="false" />
+    <!-- Pressed state -->
+    <item android:drawable="@drawable/capture_button_pressed" android:state_pressed="true" />
+</selector>

--- a/Android/app/src/main/res/drawable/capture_button_not_pressed.xml
+++ b/Android/app/src/main/res/drawable/capture_button_not_pressed.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Outer oval -->
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@color/white_50" />
+        </shape>
+    </item>
+    <!-- Inner oval -->
+    <item>
+        <shape android:shape="oval">
+            <stroke
+                android:width="14dp"
+                android:color="@color/transparent" />
+            <solid android:color="@color/white_100" />
+            <size
+                android:width="90dp"
+                android:height="90dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/Android/app/src/main/res/drawable/capture_button_pressed.xml
+++ b/Android/app/src/main/res/drawable/capture_button_pressed.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Outer oval -->
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@color/white_50" />
+        </shape>
+    </item>
+    <!-- Inner oval -->
+    <item>
+        <shape android:shape="oval">
+            <stroke
+                android:width="14dp"
+                android:color="@color/transparent" />
+            <solid android:color="#191919" />
+            <size
+                android:width="90dp"
+                android:height="90dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/Android/app/src/main/res/layout/activity_mmiw_ar.xml
+++ b/Android/app/src/main/res/layout/activity_mmiw_ar.xml
@@ -17,10 +17,11 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
+        android:id="@+id/capture_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Capture"
-        android:id="@+id/capture"
+        android:layout_marginBottom="32dp"
+        android:background="@drawable/capture_button"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="white_100">#f8f8f8</color>
+    <color name="white_50">#80f8f8f8</color>
+    <color name="transparent">#00000000</color>
+    <color name="capture_button_pressed_black">#191919</color>
+
+    <!--  Might be used in the future.  -->
     <color name="colorPrimary">#008577</color>
     <color name="colorPrimaryDark">#00574B</color>
     <color name="colorAccent">#D81B60</color>
+    <color name="red">#B10E0F</color>
 </resources>


### PR DESCRIPTION
This updates the capture button to use the Figma version. It also pauses ARCore and prevents the button from being clicked again. 

To test, just start the app and go into the MMIW Prototype.
Then tap the camera capture button :)

There's still a question I want to ask Teressa. I wasn't sure what color to make the `pressed` version of the capture button.