### PR TITLE
Android 39 add send and back button.

### DIFF
--- a/Android/.idea/codeStyles/Project.xml
+++ b/Android/.idea/codeStyles/Project.xml
@@ -3,9 +3,18 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="java.util" withSubpackages="false" static="false" />
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
-          <package name="io.ktor" withSubpackages="true" static="false" />
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/Android/app/src/main/res/drawable/ic_back.xml
+++ b/Android/app/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="46dp"
+    android:height="46dp"
+    android:viewportWidth="46"
+    android:viewportHeight="46">
+  <path
+      android:pathData="M23,23m-23,0a23,23 0,1 1,46 0a23,23 0,1 1,-46 0"
+      android:strokeAlpha="0.8"
+      android:fillColor="#F8F8F8"
+      android:fillAlpha="0.8"/>
+  <path
+      android:pathData="M10.7889,23.8944C10.0518,23.5259 10.0518,22.4741 10.7889,22.1056L22.7554,16.1223C23.5639,15.718 24.4513,16.5089 24.1424,17.3585L22.2152,22.6583C22.1349,22.879 22.1349,23.121 22.2152,23.3417L24.1424,28.6415C24.4513,29.4911 23.5639,30.282 22.7554,29.8777L10.7889,23.8944Z"
+      android:strokeAlpha="0.9"
+      android:fillColor="#191919"
+      android:fillAlpha="0.9"/>
+  <path
+      android:pathData="M21,22h14v2h-14z"
+      android:strokeAlpha="0.9"
+      android:fillColor="#191919"
+      android:fillAlpha="0.9"/>
+</vector>

--- a/Android/app/src/main/res/drawable/ic_send.xml
+++ b/Android/app/src/main/res/drawable/ic_send.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="46dp"
+    android:height="46dp"
+    android:viewportWidth="46"
+    android:viewportHeight="46">
+  <path
+      android:pathData="M23,23m-23,0a23,23 0,1 1,46 0a23,23 0,1 1,-46 0"
+      android:strokeAlpha="0.8"
+      android:fillColor="#F8F8F8"
+      android:fillAlpha="0.8"/>
+  <path
+      android:pathData="M34.2111,22.1056C34.9482,22.4741 34.9482,23.5259 34.2111,23.8944L16.2446,32.8777C15.4361,33.282 14.5487,32.4911 14.8576,31.6415L17.8757,23.3417C17.956,23.121 17.956,22.879 17.8757,22.6583L14.8576,14.3585C14.5487,13.5089 15.4361,12.718 16.2446,13.1223L34.2111,22.1056Z"
+      android:strokeAlpha="0.9"
+      android:fillColor="#191919"
+      android:fillAlpha="0.9"/>
+</vector>

--- a/Android/app/src/main/res/layout/activity_mmiw_ar.xml
+++ b/Android/app/src/main/res/layout/activity_mmiw_ar.xml
@@ -53,4 +53,59 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
+    <Button
+        android:id="@+id/back_button"
+        android:layout_width="46dp"
+        android:layout_height="46dp"
+        android:layout_marginStart="36dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/ic_back"
+        app:layout_constraintBottom_toTopOf="@+id/back_button_text_view"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/back_button_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:labelFor="@+id/back_button"
+        android:text="@string/back"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/back_button"
+        app:layout_constraintStart_toStartOf="@+id/back_button" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/back_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:constraint_referenced_ids="back_button,back_button_text_view" />
+
+    <Button
+        android:id="@+id/send_button"
+        android:layout_width="46dp"
+        android:layout_height="46dp"
+        android:layout_marginEnd="36dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/ic_send"
+        app:layout_constraintBottom_toTopOf="@+id/send_button_text_view"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/send_button_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:labelFor="@+id/send_button"
+        android:text="@string/send_to"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/send_button"
+        app:layout_constraintStart_toStartOf="@+id/send_button" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/send_to_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:constraint_referenced_ids="send_button,send_button_text_view" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="next_slide">Next</string>
     <string name="respect_agree">I Agree</string>
     <string name="respectful"><b>Please be respectful.</b> \n \nThis app\’s sole purpose is to bring awareness about #MMIWG2S. \n \nIf you would like to support the movement and add your voice, then this is the app for you. \n \nTo learn more, check out settings for links to more information. Thank you for your support." </string>
+    <string name="send_to">Send To</string>
+    <string name="back">Back</string>
 </resources>


### PR DESCRIPTION
Added the Send to and back buttons to the image edit view. They should show and hide based correctly.

If taking a picture, they shouldn't show.
After the picture is "taken", the capture button should hide and these two buttons should show.
If you tap the back button, these two should hide, the capture button should show, and the Sceneview should unpause.