### PR TITLE
Add Statistics Swipeable View

### DIFF
--- a/Android/app/src/main/java/com/mehequanna/mmiw/Statistics.kt
+++ b/Android/app/src/main/java/com/mehequanna/mmiw/Statistics.kt
@@ -1,0 +1,13 @@
+package com.mehequanna.mmiw
+
+import android.content.Context
+
+data class Statistics(val context: Context) {
+    val statisticsList = listOf(
+        context.getString(R.string.stat_text_1),
+        context.getString(R.string.stat_text_2),
+        context.getString(R.string.stat_text_3),
+        context.getString(R.string.stat_text_4),
+        context.getString(R.string.stat_text_5)
+    )
+}

--- a/Android/app/src/main/java/com/mehequanna/mmiw/adapter/StatisticsAdapter.kt
+++ b/Android/app/src/main/java/com/mehequanna/mmiw/adapter/StatisticsAdapter.kt
@@ -1,0 +1,24 @@
+package com.mehequanna.mmiw.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+class StatisticsAdapter : RecyclerView.Adapter<StatisticsViewHolder>() {
+    var list: List<String> = listOf()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StatisticsViewHolder =
+        StatisticsViewHolder(parent)
+
+    override fun onBindViewHolder(holder: StatisticsViewHolder, position: Int) {
+        holder.bind(list[position])
+    }
+
+    fun setStatisticsAdapterData(list: List<String>) {
+        this.list = list
+        notifyDataSetChanged()
+    }
+
+    override fun getItemCount(): Int = list.size
+
+    fun getCurrentItemText(position: Int): String = list[position]
+}

--- a/Android/app/src/main/java/com/mehequanna/mmiw/adapter/StatisticsViewHolder.kt
+++ b/Android/app/src/main/java/com/mehequanna/mmiw/adapter/StatisticsViewHolder.kt
@@ -1,0 +1,19 @@
+package com.mehequanna.mmiw.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.mehequanna.mmiw.R
+import kotlinx.android.synthetic.main.statistics_item.view.*
+
+class StatisticsViewHolder constructor(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    constructor(parent: ViewGroup) :
+            this(
+                LayoutInflater.from(parent.context).inflate(R.layout.statistics_item, parent, false)
+            )
+
+    fun bind(boxText: String) {
+        itemView.statisticsTextView.text = boxText
+    }
+}

--- a/Android/app/src/main/res/drawable/gradient_camera_view.xml
+++ b/Android/app/src/main/res/drawable/gradient_camera_view.xml
@@ -1,0 +1,25 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="414dp"
+    android:height="896dp"
+    android:viewportWidth="414"
+    android:viewportHeight="896">
+  <path
+      android:pathData="M0,0h414v896h-414z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startY="0"
+          android:startX="207"
+          android:endY="896"
+          android:endX="207"
+          android:type="linear">
+        <item android:offset="0" android:color="#CE000000"/>
+        <item android:offset="0.147786" android:color="#3A000000"/>
+        <item android:offset="0.34375" android:color="#00000000"/>
+        <item android:offset="0.663722" android:color="#00000000"/>
+        <item android:offset="0.766367" android:color="#60000000"/>
+        <item android:offset="1" android:color="#FF000000"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/Android/app/src/main/res/layout/activity_mmiw_ar.xml
+++ b/Android/app/src/main/res/layout/activity_mmiw_ar.xml
@@ -25,23 +25,43 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
+        <View
+            android:id="@+id/gradientView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="18dp"
-            android:background="#B3191919"
-            android:gravity="center"
-            android:padding="8dp"
-            android:text="@string/hashtag_caps"
-            android:textColor="@color/white_100"
-            android:textSize="36sp"
+            android:layout_height="match_parent"
+            android:background="@drawable/gradient_camera_view"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <!--    Add quotes carousel    -->
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/headerTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="18dp"
+            android:gravity="center"
+            android:text="@string/hashtag_caps"
+            android:textColor="@color/white_100"
+            android:textSize="@dimen/banner_text_size"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
+        <TextView
+            android:id="@+id/statisticsCaptureView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="64dp"
+            android:padding="8dp"
+            android:textAlignment="center"
+            android:textColor="@color/white_100"
+            android:textSize="@dimen/statistics_view_text_size"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <Button
         android:id="@+id/capture_button"
@@ -50,6 +70,19 @@
         android:layout_marginBottom="32dp"
         android:background="@drawable/capture_button"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/statisticsViewPager"
+        android:layout_width="match_parent"
+        android:layout_height="250dp"
+        android:layout_marginBottom="16dp"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:paddingBottom="16dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/back_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 

--- a/Android/app/src/main/res/layout/statistics_item.xml
+++ b/Android/app/src/main/res/layout/statistics_item.xml
@@ -1,0 +1,22 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/cardViewParent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/statisticsTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_marginLeft="@dimen/page_margin_and_offset"
+        android:layout_marginRight="@dimen/page_margin_and_offset"
+        android:backgroundTint="@color/transparent"
+        android:padding="8dp"
+        android:textAlignment="center"
+        android:textColor="@color/white_100"
+        android:textSize="@dimen/statistics_view_text_size"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -5,6 +5,7 @@
     <color name="transparent">#00000000</color>
     <color name="capture_button_pressed_black">#191919</color>
     <color name="red">#B10E0F</color>
+    <color name="banner_black">#B3191919</color>
     <color name="black">#000000</color>
 
     <!--  Might be used in the future.  -->

--- a/Android/app/src/main/res/values/dimens.xml
+++ b/Android/app/src/main/res/values/dimens.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="statistics_view_text_size">24sp</dimen>
+    <dimen name="banner_text_size">48sp</dimen>
+
+    <!--  View pager dimensions  -->
+    <dimen name="page_margin">20dp</dimen>
+    <dimen name="viewpager_offset">30dp</dimen>
+    <dimen name="page_margin_and_offset">50dp</dimen>
+</resources>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="stat_text_2">Between 2005–2009 U.S. attorneys declined to prosecute 67% of native community matters involving sexual abuse.</string>
     <string name="stat_text_3">84% of Native women have experienced violence in their lifetime.</string>
     <string name="stat_text_4">96% of sexual violence against native women is perpetrated by non-natives.</string>
+    <string name="stat_text_5">No more stolen sisters!</string>
     <string name="next_slide">Next</string>
     <string name="respect_agree">I Agree</string>
     <string name="respectful"><b>Please be respectful.</b> \n \nThis app\’s sole purpose is to bring awareness about #MMIWG2S. \n \nIf you would like to support the movement and add your voice, then this is the app for you. \n \nTo learn more, check out settings for links to more information. Thank you for your support." </string>


### PR DESCRIPTION
This adds the swipeable statistics view after the user has tapped capture.
After the user chooses a stat, aka, stopping on their choice and hit's `Send to`, the view pager goes invisible and a textview with the same background is created and added to the picture to be sent.