### PR TITLE
Fix share page failing to share.

### DIFF
--- a/iOS/MMIWG2S/Views/ARFaceViewerUI.swift
+++ b/iOS/MMIWG2S/Views/ARFaceViewerUI.swift
@@ -287,9 +287,11 @@ class ARFaceViewerUI: UIView {
     }
 
     private func shareImage() {
-        guard let imageToShare = imageToShare else { return }
+        guard let imageToShare = imageToShare,
+              let jpgImage = imageToShare.jpegData(compressionQuality: 0.9)
+        else { return }
 
-        let activityController = UIActivityViewController(activityItems: [imageToShare], applicationActivities: nil)
+        let activityController = UIActivityViewController(activityItems: [jpgImage], applicationActivities: nil)
         activityController.completionWithItemsHandler = { [weak self] (activityType, completed: Bool, returnedItems: [Any]?, error: Error?) in
             self?.delegate?.resumeSessionOnceCaptured()
             self?.changeViewVisibility(isCapturing: true)


### PR DESCRIPTION
Converts the UIImage to a data type of jpg. This seems to fix the shares not working with social media.